### PR TITLE
Simplify hpc setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example, here is an example for launching the BioEngine on a Slurm cluster:
 ```bash
 # Please replace the job command with your own settings
 export HYPHA_HPC_JOB_TEMPLATE="srun -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
-python -m hypha_launcher launch_bioengine_worker --service-id my-triton
+python -m hypha_launcher launch_bioengine_worker --hypha-server-url https://ai.imjoy.io --triton-service-id my-triton
 ```
 
 In the above example, the job command template is set to use the Slurm scheduler with the specified account and time limit. The `{cmd}` placeholder will be replaced with the actual command to launch jobs.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@ BioEngine consists of a set of services that are used to serve AI models from bi
 
 Download all models from s3 and launch triton server.
 
-```bash
-python -m hypha_launcher launch_bioengine_backend --service-id my-triton
-```
-
 Launch on HPC cluster. You need to set the job command template via the `HYPHA_HPC_JOB_COMMAND` environment variable for your own HPC cluster.
 
 For example, here is an example for launching the BioEngine on a Slurm cluster:
@@ -62,6 +58,12 @@ python -m hypha_launcher launch_bioengine_backend --service-id my-triton
 ```
 
 In the above example, the job command template is set to use the Slurm scheduler with the specified account and time limit. The `{cmd}` placeholder will be replaced with the actual command to launch jobs.
+
+Optionally, you can also set the store path for storing the models and the triton server configuration via the `HYPHA_LAUNCHER_STORE_DIR` environment variable. By default, the store path is set to `.hypha-launcher`.
+
+```bash
+export HYPHA_LAUNCHER_STORE_DIR=".hypha-launcher"
+```
 
 ### Download model from s3
 

--- a/README.md
+++ b/README.md
@@ -41,23 +41,27 @@ pip install hypha-launcher
 $ hypha-launcher --help
 ```
 
-### Launch the bioimage.io backend
+### Launch the BioEngine
+
+BioEngine consists of a set of services that are used to serve AI models from bioimage.io. We provide the model test run feature accessible from https://bioimage.io and a dedicated bioengine web client: https://bioimage-io.github.io/bioengine-web-client/. While our public instance is openly accessible for testing and evaluation, you can run your own instance of the BioEngine to serve the models, e.g. with your own HPC computing resources.
 
 Download all models from s3 and launch triton server.
 
 ```bash
-$ python -m hypha_launcher launch_bioimageio_backend --service-id my-triton
+python -m hypha_launcher launch_bioengine_backend --service-id my-triton
 ```
 
-Launch on slurm cluster.
+Launch on HPC cluster. You need to set the job command template via the `HYPHA_HPC_JOB_COMMAND` environment variable for your own HPC cluster.
+
+For example, here is an example for launching the BioEngine on a Slurm cluster:
 
 ```bash
-# Please replace the slurm settings with your own settings
-$ export SLURM_ACCOUNT=Your-Slurm-Account
-$ export SLURM_TIME=03:00:00
-$ export SLURM_GPUS_PER_NODE=A100:1
-$ python -m hypha_launcher launch_bioimageio_backend --service-id my-triton
+# Please replace the job command with your own settings
+export HYPHA_HPC_JOB_COMMAND="slurm -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
+python -m hypha_launcher launch_bioengine_backend --service-id my-triton
 ```
+
+In the above example, the job command template is set to use the Slurm scheduler with the specified account and time limit. The `{cmd}` placeholder will be replaced with the actual command to launch jobs.
 
 ### Download model from s3
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ BioEngine consists of a set of services that are used to serve AI models from bi
 
 Download all models from s3 and launch triton server.
 
-Launch on HPC cluster. You need to set the job command template via the `HYPHA_HPC_JOB_COMMAND` environment variable for your own HPC cluster.
+Launch on HPC cluster. You need to set the job command template via the `HYPHA_HPC_JOB_TEMPLATE` environment variable for your own HPC cluster.
 
 For example, here is an example for launching the BioEngine on a Slurm cluster:
 
 ```bash
 # Please replace the job command with your own settings
-export HYPHA_HPC_JOB_COMMAND="slurm -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
+export HYPHA_HPC_JOB_TEMPLATE="slurm -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
 python -m hypha_launcher launch_bioengine_backend --service-id my-triton
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ pip install hypha-launcher
 ## CLI Usage
 
 ```bash
-$ hypha-launcher --help
+hypha-launcher --help
 ```
 
-### Launch the BioEngine
+### Launch the BioEngine Worker on HPC
 
-BioEngine consists of a set of services that are used to serve AI models from bioimage.io. We provide the model test run feature accessible from https://bioimage.io and a dedicated bioengine web client: https://bioimage-io.github.io/bioengine-web-client/. While our public instance is openly accessible for testing and evaluation, you can run your own instance of the BioEngine to serve the models, e.g. with your own HPC computing resources.
+BioEngine consists of a set of services that are used to serve AI models from bioimage.io. We provide the model test run feature accessible from https://bioimage.io and a dedicated bioengine web client: https://bioimage-io.github.io/bioengine-web-client/. While our public instance is openly accessible for testing and evaluation, you can run your own instance of the BioEngine worker to serve the models, e.g. with your own HPC computing resources.
 
 Download all models from s3 and launch triton server.
 
@@ -54,7 +54,7 @@ For example, here is an example for launching the BioEngine on a Slurm cluster:
 ```bash
 # Please replace the job command with your own settings
 export HYPHA_HPC_JOB_TEMPLATE="srun -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
-python -m hypha_launcher launch_bioengine_backend --service-id my-triton
+python -m hypha_launcher launch_bioengine_worker --service-id my-triton
 ```
 
 In the above example, the job command template is set to use the Slurm scheduler with the specified account and time limit. The `{cmd}` placeholder will be replaced with the actual command to launch jobs.
@@ -68,13 +68,13 @@ export HYPHA_LAUNCHER_STORE_DIR=".hypha-launcher"
 ### Download model from s3
 
 ```bash
-$ python -m hypha-launcher - download_models_from_s3 bioengine-model-runner.* --n_parallel=5
+python -m hypha-launcher - download_models_from_s3 bioengine-model-runner.* --n_parallel=5
 ```
 
 ### Pull docker image of triton server
 
 ```bash
-$ python -m hypha-launcher - pull_image
+python -m hypha-launcher - pull_image
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For example, here is an example for launching the BioEngine on a Slurm cluster:
 
 ```bash
 # Please replace the job command with your own settings
-export HYPHA_HPC_JOB_TEMPLATE="slurm -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
+export HYPHA_HPC_JOB_TEMPLATE="srun -A Your-Slurm-Account -t 03:00:00 --gpus-per-node A100:1 {cmd}"
 python -m hypha_launcher launch_bioengine_backend --service-id my-triton
 ```
 

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -35,7 +35,9 @@ class HyphaLauncher:
             hpc_manager_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             executor_engine_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             ):
-        store_dir = store_dir or os.environ.get("HYPHA_LAUNCHER_STORE_DIR", ".hypha_launcher")
+        store_dir = store_dir or os.environ.get("HYPHA_LAUNCHER_STORE_DIR")
+        if store_dir is None:
+            store_dir = ".hypha_launcher"
         self.store_dir = Path(store_dir).expanduser().absolute()
         if not self.store_dir.exists():
             self.store_dir.mkdir(parents=True)

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -317,7 +317,7 @@ class HyphaLauncher:
         self._task_uuid_to_job[task_uuid] = job
         return job_dict
 
-    async def launch_bioimageio_backend(
+    async def launch_bioengine_backend(
             self,
             models_dir: T.Optional[str] = None,
             hypha_server_url: str = "https://ai.imjoy.io/",

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -29,7 +29,7 @@ logger = get_logger()
 class HyphaLauncher:
     def __init__(
             self,
-            store_dir: str = None,
+            store_dir: T.Optional[str] = None,
             debug: bool = False,
             container_engine_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             hpc_manager_kwargs: T.Optional[T.Dict[str, T.Any]] = None,

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -321,9 +321,9 @@ class HyphaLauncher:
             self,
             models_dir: T.Optional[str] = None,
             hypha_server_url: str = "https://ai.imjoy.io/",
-            service_name: str = "triton",
-            service_id: T.Optional[str] = None,
-            service_config: T.Optional[dict] = None,
+            triton_service_name: str = "triton",
+            triton_service_id: T.Optional[str] = None,
+            triton_service_config: T.Optional[dict] = None,
             ):
         if models_dir is None:
             models_dir = (self.store_dir / "models").as_posix()
@@ -363,16 +363,17 @@ class HyphaLauncher:
                 return {"error": str(e)}
 
         server = await self._get_hypha_server(hypha_server_url)
-        if service_id is None:
-            service_id = f"{service_name}-{secrets.token_urlsafe(8)}"
-        logger.info(f"Registering service: {service_name} with id: {service_id}")
-        if service_config is None:
-            service_config = {"visibility": "public"}
+        if triton_service_id is None:
+            triton_service_id = f"{triton_service_name}-{secrets.token_urlsafe(8)}"
+        logger.info(f"Registering service: {triton_service_name} with id: {triton_service_id}")
+        if triton_service_config is None:
+            triton_service_config = {"visibility": "public"}
         await server.register_service(
             {
-                "name": service_name,
-                "id": service_id,
-                "config": service_config,
+                "name": triton_service_name,
+                "id": triton_service_id,
+                "type": "triton-client",
+                "config": triton_service_config,
                 "get_config": get_triton_config,
                 "execute": execute_triton,
             }

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -29,7 +29,7 @@ logger = get_logger()
 class HyphaLauncher:
     def __init__(
             self,
-            store_dir: str = ".hypha_launcher",
+            store_dir: str = None,
             debug: bool = False,
             container_engine_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             hpc_manager_kwargs: T.Optional[T.Dict[str, T.Any]] = None,

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -380,6 +380,7 @@ class HyphaLauncher:
         )
 
         await self.engine.wait_async()
+        print(f"Bioengine worker is ready, you can try the BioEngine worker with the web client: https://bioimage-io.github.io/bioengine-web-client/?server-url={hypha_server_url}&triton-service-id={triton_service_id}")
 
     async def launch_hello_world(self):
         """Detect in which environment, docker/k8s/apptainer"""

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -317,7 +317,7 @@ class HyphaLauncher:
         self._task_uuid_to_job[task_uuid] = job
         return job_dict
 
-    async def launch_bioengine_backend(
+    async def launch_bioengine_worker(
             self,
             models_dir: T.Optional[str] = None,
             hypha_server_url: str = "https://ai.imjoy.io/",

--- a/hypha_launcher/api.py
+++ b/hypha_launcher/api.py
@@ -35,7 +35,7 @@ class HyphaLauncher:
             hpc_manager_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             executor_engine_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
             ):
-        store_dir = os.environ.get("HYPHA_LAUNCHER_STORE_DIR", store_dir)
+        store_dir = store_dir or os.environ.get("HYPHA_LAUNCHER_STORE_DIR", ".hypha_launcher")
         self.store_dir = Path(store_dir).expanduser().absolute()
         if not self.store_dir.exists():
             self.store_dir.mkdir(parents=True)

--- a/hypha_launcher/utils/container.py
+++ b/hypha_launcher/utils/container.py
@@ -17,7 +17,7 @@ class ContainerEngine:
 
     def __init__(
         self,
-        store_dir: str = "~/.hypha_launcher/containers",
+        store_dir: str = ".hypha_launcher/containers",
         engine_type: T.Optional[str] = None,
     ):
 

--- a/hypha_launcher/utils/hpc.py
+++ b/hypha_launcher/utils/hpc.py
@@ -21,17 +21,17 @@ def detect_hpc_type() -> str:
 
 
 class HPCManger:
-    def __init__(self, hpc_type: T.Optional[str] = None, hpc_job_command: T.Optional[str] = None):
+    def __init__(self, hpc_type: T.Optional[str] = None, hpc_job_template: T.Optional[str] = None):
         if hpc_type is None:
             hpc_type = detect_hpc_type()
         self.hpc_type = hpc_type
-        self.hpc_job_command = hpc_job_command or os.environ.get("HYPHA_HPC_JOB_COMMAND")
+        self.hpc_job_template = hpc_job_template or os.environ.get("HYPHA_HPC_JOB_TEMPLATE")
 
     def get_command(self, cmd: str, **attrs) -> str:
-        if self.hpc_job_command is not None:
-            if "{cmd}" in self.hpc_job_command:
-                return self.hpc_job_command.format(cmd=cmd)
-            return f"{self.hpc_job_command} {cmd}"
+        if self.hpc_job_template is not None:
+            if "{cmd}" in self.hpc_job_template:
+                return self.hpc_job_template.format(cmd=cmd)
+            return f"{self.hpc_job_template} {cmd}"
         if self.hpc_type == "slurm":
             return self.get_slurm_command(cmd, **attrs)
         elif self.hpc_type == "local":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "hypha-launcher"
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 description = "Launcher for hypha services"
 authors = [


### PR DESCRIPTION
This PR replace hardcoded slum environment into a more general `HYPHA_HPC_JOB_COMMAND`, this will allow supporting other cluster types, and more slurm arguments. Some cluster for example don't need the `account`.