### PR TITLE
Pin minio for gateway support

### DIFF
--- a/hypha_launcher/constants.py
+++ b/hypha_launcher/constants.py
@@ -3,7 +3,7 @@ S3_BASE_URL = "https://uk1s3.embassy.ebi.ac.uk"
 S3_MODELS_URL = f"{S3_BASE_URL}/model-repository/"
 S3_CONDA_ENVS_URL = f"{S3_BASE_URL}/bioimage.io/environments"
 TRITON_IMAGE = "docker://nvcr.io/nvidia/tritonserver:23.03-py3"
-S3_IMAGE = "docker://minio/minio:RELEASE.2023-10-24T04-42-36Z.hotfix.793d9ee53"
+S3_IMAGE = "docker://minio/minio:RELEASE.2022-04-29T01-27-09Z.fips"
 
 DOCKER_REGISTRY_PREFIX = "docker://ghcr.io/bioimage-io"
 


### PR DESCRIPTION
MInio has decided to deprecated the gateway / file system mode: https://blog.min.io/deprecation-of-the-minio-gateway/

This means we will have to pin the docker image to an older version if we want to operate files on disk while provide the s3 interface.

Not sure what's the longer-term solution for this, or alternatives exists.